### PR TITLE
Fix for CVE-2012-6134

### DIFF
--- a/omniauth-shopify-oauth2.gemspec
+++ b/omniauth-shopify-oauth2.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.0.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.1'
 
   s.add_development_dependency 'rspec', '~> 2.7.0'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Fix for: https://github.com/intridea/omniauth-oauth2/pull/25

http://cve.mitre.org/cgi-bin/cvename.cgi?name=2012-6134
