### PR TITLE
Add missing fields to auth hash

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -13,8 +13,16 @@ module OmniAuth
       }
 
       option :callback_url
-      
+
       option :provider_ignores_state, true
+
+      uid { request.env["rack.request.query_hash"]["shop"] }
+
+      info { { name: shop_name } }
+
+      def shop_name
+        request.env["rack.request.query_hash"]["shop"].sub('.myshopify.com', '')
+      end
 
       def authorize_params
         super.tap do |params|


### PR DESCRIPTION
Adds two missing fields to the omniauth auth hash, as per [the schema on the omniauth wiki](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema).

Fixes #2.
