### PR TITLE
bump omniauth-oauth2 dependency to 1.1.1 to pull in oauth2 0.9.x

### DIFF
--- a/omniauth-shopify-oauth2.gemspec
+++ b/omniauth-shopify-oauth2.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.1'
 
   s.add_development_dependency 'rspec', '~> 2.7.0'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
- A number of other omniauth gems are now using oauth2 0.9.x so a newer omniauth-oauth2 dependency is required.
