### PR TITLE
allow site option with http protocol

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -19,7 +19,7 @@ module OmniAuth
       uid { URI.parse(options[:client_options][:site]).host }
 
       def valid_site?
-        return /^https\:\/\/[a-zA-Z0-9][a-zA-Z0-9\-]*\.myshopify\.com[\/]?$/ =~ options[:client_options][:site]
+        return /^(https|http)\:\/\/[a-zA-Z0-9][a-zA-Z0-9\-]*\.myshopify\.com[\/]?$/ =~ options[:client_options][:site]
       end
 
       def setup_phase


### PR DESCRIPTION
The shop param is coming back from shopify with the http, not https, protocol. This change allows either protocol.
