### PR TITLE
Take advantage of OmniAuth's auth failure handling

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -22,9 +22,12 @@ module OmniAuth
         return /^https\:\/\/[a-zA-Z0-9][a-zA-Z0-9\-]*\.myshopify\.com[\/]?$/ =~ options[:client_options][:site]
       end
 
-      def setup_phase
-        super
-        raise CallbackError.new(nil, :invalid_site) unless valid_site?
+      def request_phase
+        if valid_site?
+          super
+        else
+          fail!(:invalid_site)
+        end
       end
 
       def authorize_params


### PR DESCRIPTION
@garymardell @odorcicd for review.

This resolves issue #10.

Before this change, it was really tough to handle the `invalid_site` error that occurs in the setup phase when an invalid shop URL is passed in.

Now, we call OmniAuth's `fail!` [method](https://github.com/intridea/omniauth/blob/c2a22c92a15378eaf2124282cfc3b71dc70edbd4/lib/omniauth/strategy.rb#L464-L475), which allows people to set their own behaviour for when an authentication error occurs. By default, this will redirect to `/auth/failure` in non-development environments.

Unfortunately, OmniAuth does not provide us with a way to achieve this from within the `setup_phase`, so it's done within the `request_phase` instead. The request_phase ([pretty much](https://github.com/intridea/omniauth/blob/c2a22c92a15378eaf2124282cfc3b71dc70edbd4/lib/omniauth/strategy.rb#L197-L217)) immediately follows the setup phase.
