### PR TITLE
bumping version to 1.1.4

### DIFF
--- a/lib/omniauth/shopify/version.rb
+++ b/lib/omniauth/shopify/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Shopify
-    VERSION = "1.1.3"
+    VERSION = "1.1.4"
   end
 end


### PR DESCRIPTION
The version wasn't bumped after the last commit (customizable shopify domains), so `gem update`/`bundle install` aren't fetching the latest changes.
