### PR TITLE
Update omniauth-oauth2 dependency

### DIFF
--- a/omniauth-shopify-oauth2.gemspec
+++ b/omniauth-shopify-oauth2.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.1'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2'
 
   s.add_development_dependency 'rspec', '~> 2.7.0'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
I've updated the `omniauth-oauth2` dependency, to increase compatibility with other provider gems. All the specs still pass.