### PR TITLE
Add a default value for the setup option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,11 @@ You can configure the scope, which you pass in to the `provider` method via a `H
 
 * `scope`: A comma-separated list of permissions you want to request from the user. See [the Shopify API docs](http://docs.shopify.com/api/tutorials/oauth) for a full list of available permissions.
 
-* `setup`: A lambda which dynamically sets the `site`. You must initiate the OmniAuth process by passing in a `shop` query parameter of the shop you're requesting permissions for. Ex. http://myapp.com/auth/shopify?shop=example.myshopify.com
-
 For example, to request `read_products`, `read_orders` and `write_content` permissions and display the authentication page:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :shopify, ENV['SHOPIFY_API_KEY'], ENV['SHOPIFY_SHARED_SECRET'],
-            :scope => 'read_products,read_orders,write_content',
-            :setup => lambda { |env| params = Rack::Utils.parse_query(env['QUERY_STRING'])
-                                     env['omniauth.strategy'].options[:client_options][:site] = "https://#{params['shop']}" }
+  provider :shopify, ENV['SHOPIFY_API_KEY'], ENV['SHOPIFY_SHARED_SECRET'], :scope => 'read_products,read_orders,write_content'
 end
 ```
 

--- a/example/config.ru
+++ b/example/config.ru
@@ -38,10 +38,7 @@ end
 use Rack::Session::Cookie, secret: SecureRandom.hex(64)
 
 use OmniAuth::Builder do
-  provider :shopify, ENV['SHOPIFY_API_KEY'], ENV['SHOPIFY_SHARED_SECRET'],
-           :scope => SCOPE,
-           :setup => lambda { |env| params = Rack::Utils.parse_query(env['QUERY_STRING'])
-                                    env['omniauth.strategy'].options[:client_options][:site] = "https://#{params['shop']}" }
+  provider :shopify, ENV['SHOPIFY_API_KEY'], ENV['SHOPIFY_SHARED_SECRET'], :scope => SCOPE
 end
 
 run App.new

--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -13,9 +13,14 @@ module OmniAuth
       }
 
       option :callback_url
-      
+
       option :provider_ignores_state, true
       option :myshopify_domain, 'myshopify.com'
+
+      option :setup, proc { |env|
+        request = Rack::Request.new(env)
+        env['omniauth.strategy'].options[:client_options][:site] = "https://#{request.GET['shop']}"
+      }
 
       uid { URI.parse(options[:client_options][:site]).host }
 


### PR DESCRIPTION
@kevinhughes27 & @EiNSTeiN- for review

~~Depends on and include pull #24, see the [last commit](https://github.com/Shopify/omniauth-shopify-oauth2/commit/default-setup) for this pull request's changes~~

## Problem

Right now we have boilerplate code generated for the omniauth setup option in shopify_app, which basically prevents us from making any improvements to it without updating all those apps.  For instance, we have a fix_https method which seems to only exist for the purpose of working around old setup lambdas that don't prefix the url with `http://` instead of `https://` (e.g. commit aa533f022966a001f83cbc01747d11deb76cfe6a fixed the setup lambda in the README).

Also, we should have a default just to make the gem simpler to use.

## Solution

Use `option :setup, `... to set a default proc to use for the setup.

## Possible Enhancements

We might want to consider allowing merchants to enter their shop name without the `.myshopify.com` suffix and having the setup handle that automatically for the authorization endpoint that just redirects to Shopify.  For now I have just added a test to show how that can be done.