### PR TITLE
Validate state param to prevent CSRF

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -15,8 +15,6 @@ module OmniAuth
       }
 
       option :callback_url
-
-      option :provider_ignores_state, true
       option :myshopify_domain, 'myshopify.com'
 
       option :setup, proc { |env|


### PR DESCRIPTION
Removes the `provider_ignores_state` option to prevent [CSRF](http://www.twobotechnologies.com/blog/2014/02/importance-of-state-in-oauth2.html) during the oauth flow.


@dylanahsmith for review