### PR TITLE
Explicitly exclude the query string from the callback_url.

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -83,7 +83,7 @@ module OmniAuth
       end
 
       def callback_url
-        options[:callback_url] || super
+        options[:callback_url] || full_host + script_name + callback_path
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/Shopify/omniauth-shopify-oauth2/issues/31.

For review @EiNSTeiN- @dylanahsmith 
/cc @christhomson 

In version 1.4.0, omniauth-oauth2 stopped overriding `callback_url`:

https://github.com/intridea/omniauth-oauth2/compare/v1.3.1...v1.4.0

This caused the URL to change from `full_host + script_name + callback_path` to `full_host + script_name + callback_path + query_string`, as defined in OmniAuth::Strategy:

https://github.com/intridea/omniauth/blob/c3e3aa5bbfb589db1ebed40324c7eea2e3153f8c/lib/omniauth/strategy.rb#L431-L433

This change overrides `callback_url` in omniauth-shopify-oauth2 so that the old behaviour is preserved.