### PR TITLE
Make it possible to request per-user permissions

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -33,6 +33,15 @@ module OmniAuth
 
       uid { URI.parse(options[:client_options][:site]).host }
 
+      extra do
+        if access_token
+          {
+            'associated_user' => access_token['associated_user'],
+            'scope' => access_token['scope'],
+          }
+        end
+      end
+
       def valid_site?
         !!(/\A(https|http)\:\/\/[a-zA-Z0-9][a-zA-Z0-9\-]*\.#{Regexp.quote(options[:myshopify_domain])}[\/]?\z/ =~ options[:client_options][:site])
       end

--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -115,7 +115,7 @@ module OmniAuth
           return fail!(:invalid_scope, CallbackError.new(:invalid_scope, "Scope does not match, it may have been tampered with."))
         end
         unless valid_permissions?(token)
-          return fail!(:invalid_permissions, CallbackError.new(:invalid_permissions, "Requested permission level does not match."))
+          return fail!(:invalid_permissions, CallbackError.new(:invalid_permissions, "Requested API access mode does not match."))
         end
 
         super

--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -105,7 +105,7 @@ module OmniAuth
           return fail!(:invalid_scope, CallbackError.new(:invalid_scope, "Scope does not match, it may have been tampered with."))
         end
         unless valid_permissions?(token)
-          return fail!(:invalid_permissions, CallbackError.new(:invalid_permissions, "Requested permission-level does not match."))
+          return fail!(:invalid_permissions, CallbackError.new(:invalid_permissions, "Requested permission level does not match."))
         end
 
         super
@@ -118,7 +118,7 @@ module OmniAuth
       def authorize_params
         super.tap do |params|
           params[:scope] = normalized_scopes(params[:scope] || DEFAULT_SCOPE).join(SCOPE_DELIMITER)
-          params[:grant_options] = 'per-user' if options[:per_user_permissions]
+          params[:grant_options] = ['per-user'] if options[:per_user_permissions]
         end
       end
 

--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -37,6 +37,7 @@ module OmniAuth
         if access_token
           {
             'associated_user' => access_token['associated_user'],
+            'associated_user_scope' => access_token['associated_user_scope'],
             'scope' => access_token['scope'],
           }
         end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -18,6 +18,14 @@ class IntegrationTest < Minitest::Test
     assert_equal "123", redirect_params['client_id']
     assert_equal "https://app.example.com/auth/shopify/callback", redirect_params['redirect_uri']
     assert_equal "read_products", redirect_params['scope']
+    assert_nil redirect_params['grant_options']
+  end
+
+  def test_authorize_includes_auth_type_when_per_user_permissions_are_requested
+    build_app(per_user_permissions: true)
+    response = authorize('snowdevil.myshopify.com')
+    redirect_params = Rack::Utils.parse_query(URI(response.location).query)
+    assert_equal 'per-user', redirect_params['grant_options']
   end
 
   def test_authorize_overrides_site_with_https_scheme
@@ -178,7 +186,7 @@ class IntegrationTest < Minitest::Test
   def test_callback_with_mismatching_scope_fails
     access_token = SecureRandom.hex(16)
     code = SecureRandom.hex(16)
-    expect_access_token_request(access_token, 'some_invalid_scope')
+    expect_access_token_request(access_token, 'some_invalid_scope', nil)
 
     response = callback(sign_params(shop: 'snowdevil.myshopify.com', code: code, state: opts["rack.session"]["omniauth.state"]))
 
@@ -247,6 +255,44 @@ class IntegrationTest < Minitest::Test
     assert_callback_success(response, access_token, code)
   end
 
+  def test_callback_when_per_user_permissions_are_present_but_not_requested
+    build_app(scope: 'scope', per_user_permissions: false)
+
+    access_token = SecureRandom.hex(16)
+    code = SecureRandom.hex(16)
+    expect_access_token_request(access_token, 'scope', { id: 1, email: 'bob@bobsen.com'})
+
+    response = callback(sign_params(shop: 'snowdevil.myshopify.com', code: code, state: opts["rack.session"]["omniauth.state"]))
+
+    assert_equal 302, response.status
+    assert_equal '/auth/failure?message=invalid_permissions&strategy=shopify', response.location
+  end
+
+  def test_callback_when_per_user_permissions_are_not_present_but_requested
+    build_app(scope: 'scope', per_user_permissions: true)
+
+    access_token = SecureRandom.hex(16)
+    code = SecureRandom.hex(16)
+    expect_access_token_request(access_token, 'scope', nil)
+
+    response = callback(sign_params(shop: 'snowdevil.myshopify.com', code: code, state: opts["rack.session"]["omniauth.state"]))
+
+    assert_equal 302, response.status
+    assert_equal '/auth/failure?message=invalid_permissions&strategy=shopify', response.location
+  end
+
+  def test_callback_works_when_per_user_permissions_are_present_and_requested
+    build_app(scope: 'scope', per_user_permissions: true)
+
+    access_token = SecureRandom.hex(16)
+    code = SecureRandom.hex(16)
+    expect_access_token_request(access_token, 'scope', { id: 1, email: 'bob@bobsen.com'})
+
+    response = callback(sign_params(shop: 'snowdevil.myshopify.com', code: code, state: opts["rack.session"]["omniauth.state"]))
+
+    assert_equal 200, response.status
+  end
+
   private
 
   def sign_params(params)
@@ -259,9 +305,9 @@ class IntegrationTest < Minitest::Test
     params
   end
 
-  def expect_access_token_request(access_token, scope)
+  def expect_access_token_request(access_token, scope, associated_user=nil)
     FakeWeb.register_uri(:post, "https://snowdevil.myshopify.com/admin/oauth/access_token",
-                         body: JSON.dump(access_token: access_token, scope: scope),
+                         body: JSON.dump(access_token: access_token, scope: scope, associated_user: associated_user),
                          content_type: 'application/json')
   end
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -13,7 +13,7 @@ class IntegrationTest < Minitest::Test
   def test_authorize
     response = authorize('snowdevil.myshopify.com')
     assert_equal 302, response.status
-    assert_match /\A#{Regexp.quote("https://snowdevil.myshopify.com/admin/oauth/authorize?")}/, response.location
+    assert_match %r{\A#{Regexp.quote(shopify_authorize_url)}}, response.location
     redirect_params = Rack::Utils.parse_query(URI(response.location).query)
     assert_equal "123", redirect_params['client_id']
     assert_equal "https://app.example.com/auth/shopify/callback", redirect_params['redirect_uri']
@@ -25,7 +25,7 @@ class IntegrationTest < Minitest::Test
     build_app(per_user_permissions: true)
     response = authorize('snowdevil.myshopify.com')
     redirect_params = Rack::Utils.parse_query(URI(response.location).query)
-    assert_equal 'per-user', redirect_params['grant_options']
+    assert_equal 'per-user', redirect_params['grant_options[]']
   end
 
   def test_authorize_overrides_site_with_https_scheme
@@ -35,7 +35,7 @@ class IntegrationTest < Minitest::Test
     }
 
     response = authorize('snowdevil.myshopify.com')
-    assert_match /\A#{Regexp.quote("https://snowdevil.myshopify.com/admin/oauth/authorize?")}/, response.location
+    assert_match %r{\A#{Regexp.quote(shopify_authorize_url)}}, response.location
   end
 
   def test_site_validation
@@ -150,7 +150,7 @@ class IntegrationTest < Minitest::Test
 
     response = authorize('snowdevil')
     assert_equal 302, response.status
-    assert_match /\A#{Regexp.quote("https://snowdevil.myshopify.dev:3000/admin/oauth/authorize?")}/, response.location
+    assert_match %r{\A#{Regexp.quote("https://snowdevil.myshopify.dev:3000/admin/oauth/authorize?")}}, response.location
     redirect_params = Rack::Utils.parse_query(URI(response.location).query)
     assert_equal 'read_products,read_orders,write_content', redirect_params['scope']
     assert_equal 'https://app.example.com/admin/auth/legacy/callback', redirect_params['redirect_uri']
@@ -328,7 +328,7 @@ class IntegrationTest < Minitest::Test
   def assert_auth_failure(response, reason)
     assert_nil FakeWeb.last_request
     assert_equal 302, response.status
-    assert_match /\A#{Regexp.quote("/auth/failure?message=#{reason}")}/, response.location
+    assert_match %r{\A#{Regexp.quote("/auth/failure?message=#{reason}")}}, response.location
   end
 
   def build_app(options={})
@@ -359,5 +359,9 @@ class IntegrationTest < Minitest::Test
 
   def request
     Rack::MockRequest.new(@app)
+  end
+
+  def shopify_authorize_url
+    "https://snowdevil.myshopify.com/admin/oauth/authorize?"
   end
 end


### PR DESCRIPTION
Adds support in omniauth-shopify-oauth2 for upcoming online-mode access tokens (scoped to user permissions).

@clayton-shopify @Shopify/api for review