### PR TITLE
Whitespace mismatch causes scope failure.

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -49,7 +49,7 @@ module OmniAuth
       def valid_scope?(token)
         params = options.authorize_params.merge(options_for("authorize"))
         return false unless token && params[:scope] && token['scope']
-        (params[:scope].split(',').sort == token['scope'].split(',').sort)
+        (params[:scope].delete(' ').split(',').sort == token['scope'].delete(' ').split(',').sort)
       end
 
       def self.encoded_params_for_signature(params)


### PR DESCRIPTION
With multiple scope params, the params[:scope] comes pre-cleaned of whitespace, so no changes to the config will propagate to this step. The token['scope'] however, includes whitespace. This causes a failure for > 1 scope regardless of validity. 

Documentation is unclear / conflicting as to whether whitespace should be included in the scopes list, nor is it a meaningful distinction that should fail a validity test.  