### PR TITLE
fix: Normalize scope option before comparing it with the actual scope.

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -49,7 +49,8 @@ module OmniAuth
       def valid_scope?(token)
         params = options.authorize_params.merge(options_for("authorize"))
         return false unless token && params[:scope] && token['scope']
-        (params[:scope].split(',').sort == token['scope'].split(',').sort)
+        expected_scope = params[:scope].split(',').map(&:strip).reject(&:empty?).uniq.sort
+        (expected_scope == token['scope'].split(',').sort)
       end
 
       def self.encoded_params_for_signature(params)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -85,6 +85,17 @@ class IntegrationTest < Minitest::Test
     assert_callback_success(response, access_token, code)
   end
 
+  def test_callback_with_spaces_in_scope
+    build_app scope: 'write_products, read_orders'
+    access_token = SecureRandom.hex(16)
+    code = SecureRandom.hex(16)
+    expect_access_token_request(access_token, 'read_orders,write_products')
+
+    response = callback(sign_params(shop: 'snowdevil.myshopify.com', code: code, state: opts["rack.session"]["omniauth.state"]))
+
+    assert_callback_success(response, access_token, code)
+  end
+
   def test_callback_rejects_invalid_hmac
     @secret = 'wrong_secret'
     response = callback(sign_params(shop: 'snowdevil.myshopify.com', code: SecureRandom.hex(16)))


### PR DESCRIPTION
Closes #38 

@EiNSTeiN- for review
cc @averydev

Adds a regression test for this bug which was from spaces in the scope used in the configuration options, which needed to be normalized before being compared to the scope returned from the server.