### PR TITLE
Normalize and remove unnecessary access scopes (implied read scopes)

### DIFF
--- a/lib/omniauth/shopify/version.rb
+++ b/lib/omniauth/shopify/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Shopify
-    VERSION = "1.1.13"
+    VERSION = "1.1.14"
   end
 end


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify_app/issues/221#issuecomment-188441518 reported by @mhoanghold

Read scopes that have a corresponding write scope are removed from the list that is returned by Shopify.

Review: @dylanahsmith @kevinhughes27