### PR TITLE
feature: Allow the scope to be passed in as an array.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ end
 
 You can configure the scope, which you pass in to the `provider` method via a `Hash`:
 
-* `scope`: A comma-separated list of permissions you want to request from the user. See [the Shopify API docs](http://docs.shopify.com/api/tutorials/oauth) for a full list of available permissions.
+* `scope`: An array of permissions you want to request from the user. See [the Shopify API docs](http://docs.shopify.com/api/tutorials/oauth) for a full list of available permissions.
 
 For example, to request `read_products`, `read_orders` and `write_content` permissions and display the authentication page:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :shopify, ENV['SHOPIFY_API_KEY'], ENV['SHOPIFY_SHARED_SECRET'], :scope => 'read_products,read_orders,write_content'
+  provider :shopify, ENV['SHOPIFY_API_KEY'], ENV['SHOPIFY_SHARED_SECRET'], :scope => ['read_products', 'read_orders', 'write_content']
 end
 ```
 

--- a/example/config.ru
+++ b/example/config.ru
@@ -2,7 +2,7 @@ require 'bundler/setup'
 require 'sinatra/base'
 require 'omniauth-shopify-oauth2'
 
-SCOPE = 'read_products,read_orders,read_customers,write_shipping'
+SCOPE = ['read_products', 'read_orders', 'read_customers', 'write_shipping']
 SHOPIFY_API_KEY = ENV['SHOPIFY_API_KEY']
 SHOPIFY_SHARED_SECRET = ENV['SHOPIFY_SHARED_SECRET']
 

--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -29,6 +29,11 @@ module OmniAuth
 
       uid { URI.parse(options[:client_options][:site]).host }
 
+      def initialize(*args, &block)
+        super(*args, &block)
+        options[:scope] = options[:scope].join(',') if options[:scope].is_a?(Array)
+      end
+
       def valid_site?
         !!(/\A(https|http)\:\/\/[a-zA-Z0-9][a-zA-Z0-9\-]*\.#{Regexp.quote(options[:myshopify_domain])}[\/]?\z/ =~ options[:client_options][:site])
       end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -96,6 +96,17 @@ class IntegrationTest < Minitest::Test
     assert_callback_success(response, access_token, code)
   end
 
+  def test_callback_with_array_as_scope
+    build_app scope: ['write_products', 'read_orders']
+    access_token = SecureRandom.hex(16)
+    code = SecureRandom.hex(16)
+    expect_access_token_request(access_token, 'read_orders,write_products')
+
+    response = callback(sign_params(shop: 'snowdevil.myshopify.com', code: code, state: opts["rack.session"]["omniauth.state"]))
+
+    assert_callback_success(response, access_token, code)
+  end
+
   def test_callback_rejects_invalid_hmac
     @secret = 'wrong_secret'
     response = callback(sign_params(shop: 'snowdevil.myshopify.com', code: SecureRandom.hex(16)))


### PR DESCRIPTION
@EiNSTeiN- for review
cc @minasmart 

Based on recommendation in issue #41

This allows the scope to be passed in as an array of strings, which is more natural for a ruby API

```ruby
provider :shopify, ENV['SHOPIFY_API_KEY'], ENV['SHOPIFY_SHARED_SECRET'], scope: ['read_products', 'read_orders', 'write_content']
```