### PR TITLE
Use a group email address in gemspec

### DIFF
--- a/omniauth-shopify-oauth2.gemspec
+++ b/omniauth-shopify-oauth2.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name     = 'omniauth-shopify-oauth2'
   s.version  = OmniAuth::Shopify::VERSION
   s.authors  = ['Denis Odorcic']
-  s.email    = ['denis.odorcic@shopify.com']
+  s.email    = ['gems@shopify.com']
   s.summary  = 'Shopify strategy for OmniAuth'
   s.homepage = 'https://github.com/Shopify/omniauth-shopify-oauth2'
   s.license = 'MIT'


### PR DESCRIPTION
@jduff, @camilo, @rafaelfranca, @EiNSTeiN- for review

## Problem

Use an individual's email address for a Shopify authored gem can cause it to become unusable after that employee leaves.  These addresses might get used to try to report a security issue.

## Solution

Use gems@shopify.com which we already use in [browser_sniffer](https://github.com/Shopify/browser_sniffer/blob/v1.0.9/browser_sniffer.gemspec#L7).

Alternatively, we could use something like security+gems@shopify.com if we want these emails are only used for security purposes.