### PR TITLE
Lock oauth2 gem at v1.1.0 to avoid oauth2 bug

### DIFF
--- a/omniauth-shopify-oauth2.gemspec
+++ b/omniauth-shopify-oauth2.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2'
+  s.add_runtime_dependency 'oauth2', '~> 1.1.0'
 
   s.add_development_dependency 'minitest', '~> 5.6'
   s.add_development_dependency 'fakeweb', '~> 1.3'


### PR DESCRIPTION
See https://github.com/intridea/oauth2/issues/270

One of the internal Shopify apps stopped allowing anyone with non-ASCII
names to log in to the application after bumping to oauth2 v1.2.0. The
linked Github issue describes how the gem is now doing unecessary string
encoding even on the happy path with data who's encoding is not yet
known. Until this bug is resolved, anyone authenticating against the
Shopify OAuth 2 API shouldn't use that gem. This locks us at the most
recent working version.

From an internal application log:

```
2016-10-20T13:19:06.106954+00:00 app[web.3]: Started GET “/auth/shopify/callback?." for 88.102.95.107 at 2016-10-20 13:19:05 +0000
2016-10-20T13:19:06.106971+00:00 app[web.3]: ** [Airbrake] Unable to contact the Airbrake server. HTTP Error=hostname "exceptions.shopify.com" does not match the server certificate
2016-10-20T13:19:06.106972+00:00 app[web.3]: ** [Airbrake] Failure: NilClass
2016-10-20T13:19:06.106972+00:00 app[web.3]:
2016-10-20T13:19:06.106974+00:00 app[web.3]: Encoding::UndefinedConversionError ("\xC3" to UTF-8 in conversion from ASCII-8BIT to UTF-8 to US-ASCII):
2016-10-20T13:19:06.106975+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/gems/oauth2-1.2.0/lib/oauth2/error.rb:30:in `encode'
2016-10-20T13:19:06.106976+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/gems/oauth2-1.2.0/lib/oauth2/error.rb:30:in `error_message'
2016-10-20T13:19:06.106977+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/gems/oauth2-1.2.0/lib/oauth2/error.rb:17:in `initialize'
2016-10-20T13:19:06.106977+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/gems/oauth2-1.2.0/lib/oauth2/client.rb:139:in `new'
2016-10-20T13:19:06.106978+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/gems/oauth2-1.2.0/lib/oauth2/client.rb:139:in `get_token'
2016-10-20T13:19:06.106979+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/gems/oauth2-1.2.0/lib/oauth2/strategy/auth_code.rb:29:in `get_token'
2016-10-20T13:19:06.106981+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/gems/omniauth-oauth2-1.4.0/lib/omniauth/strategies/oauth2.rb:89:in `build_access_token'
2016-10-20T13:19:06.106981+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/bundler/gems/omniauth-shopify-oauth2-cd1f75e5e9bb/lib/omniauth/strategies/shopify.rb:125:in `build_access_token'
2016-10-20T13:19:06.106982+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/bundler/gems/omniauth-shopify-oauth2-cd1f75e5e9bb/lib/omniauth/strategies/shopify.rb:113:in `callback_phase'
2016-10-20T13:19:06.106983+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/gems/omniauth-1.3.1/lib/omniauth/strategy.rb:227:in `callback_call'
2016-10-20T13:19:06.106983+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/gems/omniauth-1.3.1/lib/omniauth/strategy.rb:184:in `call!'
2016-10-20T13:19:06.106984+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/gems/omniauth-1.3.1/lib/omniauth/strategy.rb:164:in `call'
2016-10-20T13:19:06.106985+00:00 app[web.3]:   vendor/bundle/ruby/2.1.0/gems/omniauth-1.3.1/lib/omniauth/builder.rb:63:in `call'
```

@jeromecornet @jahfer @EiNSTeiN- 