### PR TITLE
Handle immutable strings in the omniauth.rb file

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -90,7 +90,7 @@ module OmniAuth
       end
 
       def fix_https
-        options[:client_options][:site].gsub!(/\Ahttp\:/, 'https:')
+        options[:client_options][:site] = options[:client_options][:site].gsub(/\Ahttp\:/, 'https:')
       end
 
       def setup_phase

--- a/spec/omniauth/strategies/shopify_spec.rb
+++ b/spec/omniauth/strategies/shopify_spec.rb
@@ -29,6 +29,12 @@ describe OmniAuth::Strategies::Shopify do
       subject.options[:client_options][:site].should eq('https://foo.bar/')
     end
 
+    it 'replaces http scheme by https with an immutable string' do
+      @options = {:client_options => {:site => 'http://foo.bar/'.freeze}}
+      subject.fix_https
+      subject.options[:client_options][:site].should eq('https://foo.bar/')
+    end
+
     it 'does not replace https scheme' do
       @options = {:client_options => {:site => 'https://foo.bar/'}}
       subject.fix_https


### PR DESCRIPTION
@EiNSTeiN- @Hammadk 

If you have an omniauth.rb file using the new `# frozen_string_literal: true` (in preparation for Ruby 3) that looks something like:

    # frozen_string_literal: true
    shopify_setup = lambda do |env|
       request = Rack::Request.new(env)
       ....
      env['omniauth.strategy'].options[:client_options][:site] = 'https://someshopurl.com'
      ...

then the gsub that's present in the strategy file will cause exceptions on the frozen string. This PR creates a copy of the string instead so that it doesn't care whether the input is frozen.