### PR TITLE
Packaging for release v1.2.0

### DIFF
--- a/lib/omniauth/shopify/version.rb
+++ b/lib/omniauth/shopify/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Shopify
-    VERSION = "1.1.17"
+    VERSION = "1.2.0"
   end
 end


### PR DESCRIPTION
As per discussion in https://github.com/Shopify/omniauth-shopify-oauth2/pull/58 we are doing a minor version bump, since there will be now a minimum requirement of v2.1.9 rails for this gem