### PR TITLE
Bump omniauth oauth2 dep

### DIFF
--- a/lib/omniauth/shopify/version.rb
+++ b/lib/omniauth/shopify/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Shopify
-    VERSION = "1.2.0"
+    VERSION = "1.2.1"
   end
 end

--- a/omniauth-shopify-oauth2.gemspec
+++ b/omniauth-shopify-oauth2.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.1.9'
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.4.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.5.0'
 
   s.add_development_dependency 'minitest', '~> 5.6'
   s.add_development_dependency 'fakeweb', '~> 1.3'


### PR DESCRIPTION
Bumps `omniauth-oauth2` dependency from `1.4.0` to `1.5.0`