### PR TITLE
When verifying the signature, use the old client secret if validation fails

### DIFF
--- a/lib/omniauth/shopify/version.rb
+++ b/lib/omniauth/shopify/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Shopify
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end


### PR DESCRIPTION
When verifying the signature, use the old client secret if validation with the new one fails