### PR TITLE
Get shop from session by default, fallback to shop param

### DIFF
--- a/lib/omniauth/shopify/version.rb
+++ b/lib/omniauth/shopify/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Shopify
-    VERSION = "1.2.1"
+    VERSION = "2.0.0"
   end
 end

--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -23,8 +23,16 @@ module OmniAuth
       option :per_user_permissions, false
 
       option :setup, proc { |env|
-        request = Rack::Request.new(env)
-        env['omniauth.strategy'].options[:client_options][:site] = "https://#{request.GET['shop']}"
+        strategy = env['omniauth.strategy']
+
+        shopify_auth_params = strategy.session['shopify.omniauth_params'] && strategy.session['shopify.omniauth_params'].with_indifferent_access
+        shop = if shopify_auth_params && shopify_auth_params['shop']
+          "https://#{shopify_auth_params['shop']}"
+        else
+          ''
+        end
+
+        strategy.options[:client_options][:site] = shop
       }
 
       uid { URI.parse(options[:client_options][:site]).host }

--- a/omniauth-shopify-oauth2.gemspec
+++ b/omniauth-shopify-oauth2.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.9'
 
   s.add_runtime_dependency 'omniauth-oauth2', '~> 1.5.0'
+  s.add_runtime_dependency 'activesupport'
 
   s.add_development_dependency 'minitest', '~> 5.6'
   s.add_development_dependency 'fakeweb', '~> 1.3'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'omniauth-shopify-oauth2'
 require 'minitest/autorun'
 require 'fakeweb'
 require 'json'
+require 'active_support/core_ext/hash'
 
 OmniAuth.config.logger = Logger.new(nil)
 FakeWeb.allow_net_connect = false


### PR DESCRIPTION
Last year [we switched `shopify_app` over to storing the shop name in the session](https://github.com/Shopify/shopify_app/pull/460) instead of sending it as a param to omniauth. However the `setup` key in the example app was not updated, nor was the README, leading to `invalid_site` errors for developers (including me). Most of our internal apps override this method to grab the shop out of the session, despite this not really being documented anywhere.

Ideally developers shouldn't have to set this key at all and this library should _just work_. This PR makes the auth route pull the shop from session, falling back to the param as it did before.