### PR TITLE
Add user session information to auth_hash

### DIFF
--- a/lib/omniauth/shopify/version.rb
+++ b/lib/omniauth/shopify/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Shopify
-    VERSION = "2.1.0"
+    VERSION = "2.2.0"
   end
 end

--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -44,6 +44,7 @@ module OmniAuth
             'associated_user' => access_token['associated_user'],
             'associated_user_scope' => access_token['associated_user_scope'],
             'scope' => access_token['scope'],
+            'session' => access_token['session']
           }
         end
       end


### PR DESCRIPTION
The Shopify Omniauth2 gem selectively wraps the parameters it receives into a custom Hash object.
It discards all parameters that are not specified as part of the strategy.

Since we now pass a user session along with per-user tokens, we need to ensure that the auth hash object constructed by the gem has the session information.

This PR adds the session to the auth hash.