### PR TITLE
Gracefully handle OAuth2 errors

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -127,6 +127,8 @@ module OmniAuth
         end
 
         super
+      rescue ::OAuth2::Error => e
+        fail!(:invalid_credentials, e)
       end
 
       def build_access_token

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -345,7 +345,7 @@ class IntegrationTest < Minitest::Test
       body: "Token is invalid or has already been requested"
     )
 
-    signed_params = sign_with_old_secret(
+    signed_params = sign_with_new_secret(
       shop: 'snowdevil.myshopify.com',
       code: SecureRandom.hex(16),
       state: opts["rack.session"]["omniauth.state"]


### PR DESCRIPTION
The underlying `OAuth2::Client` can raise an `OAuth2::Error` upon receiving a bad response during the token exchange.

The OAuth2 strategy [handles this error](https://github.com/omniauth/omniauth-oauth2/blob/master/lib/omniauth/strategies/oauth2.rb#L77) in the `#callback_phase` method. However, the Shopify strategy overrides this method and still calls `#build_access_token` so the error can bubble up (much to the dismay of my production app 😢).

Resolves #85