### PR TITLE
Valid permissions handles nil

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -94,7 +94,12 @@ module OmniAuth
       end
 
       def valid_permissions?(token)
-        token && (options[:per_user_permissions] == !token['associated_user'].nil?)
+        return false unless token
+
+        return true if options[:per_user_permissions] && token['associated_user']
+        return true if !options[:per_user_permissions] && !token['associated_user']
+
+        false
       end
 
       def fix_https

--- a/omniauth-shopify-oauth2.gemspec
+++ b/omniauth-shopify-oauth2.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport'
 
   s.add_development_dependency 'minitest', '~> 5.6'
+  s.add_development_dependency 'rspec', '~> 3.9.0'
   s.add_development_dependency 'fakeweb', '~> 1.3'
   s.add_development_dependency 'rake'
 end

--- a/spec/omniauth/strategies/shopify_spec.rb
+++ b/spec/omniauth/strategies/shopify_spec.rb
@@ -140,4 +140,80 @@ describe OmniAuth::Strategies::Shopify do
       subject.valid_site?.should eq(true)
     end
   end
+
+  describe '#valid_permissions?' do
+    let(:associated_user) do
+      {}
+    end
+
+    let(:token) do
+      {
+        'associated_user' => associated_user,
+      }
+    end
+
+    it 'returns false if there is no token' do
+      expect(subject.valid_permissions?(nil)).to be_falsey
+    end
+
+    context 'with per_user_permissions is present' do
+      before do
+        @options = @options.merge(per_user_permissions: true)
+      end
+
+      context 'when token does not have associated user' do
+        let(:associated_user) { nil }
+
+        it 'return false' do
+          expect(subject.valid_permissions?(token)).to be_falsey
+        end
+      end
+
+      context 'when token has associated user' do
+        it 'return true' do
+          expect(subject.valid_permissions?(token)).to be_truthy
+        end
+      end
+    end
+
+    context 'with per_user_permissions is false' do
+      before do
+        @options = @options.merge(per_user_permissions: false)
+      end
+
+      context 'when token does not have associated user' do
+        let(:associated_user) { nil }
+
+        it 'return true' do
+          expect(subject.valid_permissions?(token)).to be_truthy
+        end
+      end
+
+      context 'when token has associated user' do
+        it 'return false' do
+          expect(subject.valid_permissions?(token)).to be_falsey
+        end
+      end
+    end
+
+    context 'with per_user_permissions is nil' do
+      before do
+        @options = @options.merge(per_user_permissions: nil)
+      end
+
+      context 'when token does not have associated user' do
+        let(:associated_user) { nil }
+
+        it 'return true' do
+          expect(subject.valid_permissions?(token)).to be_truthy
+        end
+      end
+
+      context 'when token has associated user' do
+        it 'return false' do
+          expect(subject.valid_permissions?(token)).to be_falsey
+        end
+      end
+    end
+  end
 end

--- a/spec/omniauth/strategies/shopify_spec.rb
+++ b/spec/omniauth/strategies/shopify_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'omniauth-shopify-oauth2'
 require 'base64'
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -280,6 +280,18 @@ class IntegrationTest < Minitest::Test
     assert_equal '/auth/failure?message=invalid_permissions&strategy=shopify', response.location
   end
 
+  def test_callback_when_per_user_permissions_are_not_present_and_options_is_nil
+    build_app(scope: 'scope', per_user_permissions: nil)
+
+    access_token = SecureRandom.hex(16)
+    code = SecureRandom.hex(16)
+    expect_access_token_request(access_token, 'scope', nil)
+
+    response = callback(sign_with_new_secret(shop: 'snowdevil.myshopify.com', code: code, state: opts["rack.session"]["omniauth.state"]))
+
+    assert_callback_success(response, access_token, code)
+  end
+
   def test_callback_when_per_user_permissions_are_not_present_but_requested
     build_app(scope: 'scope', per_user_permissions: true)
 


### PR DESCRIPTION
### What are you trying to accomplish?
Allow `valid_permissions(token)?` to properly handle the case when `per_user_permissions` options is `nil`.

Refactor tests to use rspec.

### What approach did you choose and why?
Added checks to see whether the `per_user_permissions` and `associated_user` are present.
Given token exists, if either are present and/or true, then `valid_permissions(token)` results in true.
Given token exists, if either are not present and/or false, then `valid_permissions(token)` results in false.
If token does not exist or is false, then `valid_permissions(token)` results in false.

### What should reviewers focus on?
`valid_permissions(token)?` method. See: `lib/omniauth/strategies/shopify.rb`
Subsequent tests that ensure `valid_permissions(token)?` handles the correct cases appropriately.

### The impact of these changes
Prevents omniauth Callback Errors from occurring when `per_user_permissions` is nil and `associate_user` does not exist in the token when using a Shop session storage strategy.

### Before you deploy
* [x] I tophatted or tested this change.
* [x] This PR is safe to rollback.
