### PR TITLE
Allow pass shop to omniauth strategy as param

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,35 @@ Authenticate the user by having them visit /auth/shopify with a `shop` query par
 </form>
 ```
 
+Or without form `/auth/shopify?shop=your-shop-url.myshopify.com`
+Alternatively you can put shop parameter to session as [Shopify App](https://github.com/Shopify/shopify_app) do
+
+```ruby
+session['shopify.omniauth_params'] = { shop: params[:shop] }
+```
+
+And finally it's possible to use your own query parameter by overriding default setup method. For example, like below:
+
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :shopify,
+    ENV['SHOPIFY_API_KEY'],
+    ENV['SHOPIFY_SHARED_SECRET'],
+    option :setup, proc { |env|
+      strategy = env['omniauth.strategy']
+
+
+
+      site = if strategy.request.params['site']
+        "https://#{strategy.request.params['site']}"
+      else
+        ''
+      end
+
+      env['omniauth.strategy'].options[:client_options][:site] = site
+    }
+```
+
 ## Configuring
 
 ### Scope

--- a/example/config.ru
+++ b/example/config.ru
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'sinatra/base'
+require 'active_support/core_ext/hash'
 require 'omniauth-shopify-oauth2'
 
 SCOPE = 'read_products,read_orders,read_customers,write_shipping'

--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -26,7 +26,11 @@ module OmniAuth
       option :setup, proc { |env|
         strategy = env['omniauth.strategy']
 
-        shopify_auth_params = strategy.session['shopify.omniauth_params'] && strategy.session['shopify.omniauth_params'].with_indifferent_access
+        shopify_auth_params = strategy.session['shopify.omniauth_params'] ||
+          strategy.session['omniauth.params'] ||
+          strategy.request.params
+
+        shopify_auth_params = shopify_auth_params && shopify_auth_params.with_indifferent_access
         shop = if shopify_auth_params && shopify_auth_params['shop']
           "https://#{shopify_auth_params['shop']}"
         else

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -169,6 +169,17 @@ class IntegrationTest < Minitest::Test
     assert_equal 'https://app.example.com/auth/shopify/callback', redirect_params['redirect_uri']
   end
 
+  def test_default_setup_reads_shop_from_params
+    build_app
+
+    response = request.get('https://app.example.com/auth/shopify?shop=snowdevil.myshopify.com', opts)
+
+    assert_equal 302, response.status
+    assert_match %r{\A#{Regexp.quote("https://snowdevil.myshopify.com/admin/oauth/authorize?")}}, response.location
+    redirect_params = Rack::Utils.parse_query(URI(response.location).query)
+    assert_equal 'https://app.example.com/auth/shopify/callback', redirect_params['redirect_uri']
+  end
+
   def test_unnecessary_read_scopes_are_removed
     build_app scope: 'read_content,read_products,write_products',
               callback_path: '/admin/auth/legacy/callback',


### PR DESCRIPTION
Based on #72 

I need to use [omniauth-shopify-oauth2](https://github.com/Shopify/omniauth-shopify-oauth2) without [shopify_app](https://github.com/Shopify/shopify_app). And it looks like it requires custom client option [setup](https://github.com/Shopify/omniauth-shopify-oauth2/blob/master/lib/omniauth/strategies/shopify.rb#L26)
Another option is to duplicate shopify_app controller sessions#login

This pr allows to get shop name from params if it hasn't been provided with `session['shopify.omniauth_params']`