### PR TITLE
normalized_scopes takes unauthenticated into account

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gemspec
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2")
   gem 'rack', '~> 1.6'
 end
+
+group :development, :test do
+  gem 'fakeweb', git: 'https://github.com/chrisk/fakeweb.git'
+end

--- a/lib/omniauth/shopify/version.rb
+++ b/lib/omniauth/shopify/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Shopify
-    VERSION = "2.2.2"
+    VERSION = "2.2.3"
   end
 end

--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -82,7 +82,7 @@ module OmniAuth
 
       def normalized_scopes(scopes)
         scope_list = scopes.to_s.split(SCOPE_DELIMITER).map(&:strip).reject(&:empty?).uniq
-        ignore_scopes = scope_list.map { |scope| scope =~ /\Awrite_(.*)\z/ && "read_#{$1}" }.compact
+        ignore_scopes = scope_list.map { |scope| scope =~ /\A(unauthenticated_)?write_(.*)\z/ && "#{$1}read_#{$2}" }.compact
         scope_list - ignore_scopes
       end
 


### PR DESCRIPTION
Scopes take the form of {auth_type}_{mode}_{resource}. This corrects
the normalized_scopes method to take auth_type into account.