### PR TITLE
Move CI to Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         version: [2.5.0, 2.7.1]
 
     steps:
-      - uses: ruby/checkout@v2
+      - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.version }}
         uses: ruby/setup-ruby@v1
         with: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Install dependencies
         run: bundle
       - name: Run Tests
-        run: bundle exec rake test
+        run: bundle exec rake
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: 
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.version }}
+    strategy:
+      matrix:
+        version: [2.5.0, 2.7.1]
+
+    steps:
+      - uses: ruby/checkout@v2
+      - name: Set up Ruby ${{ matrix.version }}
+        uses: ruby/setup-ruby@v1
+        with: 
+          ruby-version: ${{ matrix.version }}
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle
+      - name: Run Tests
+        run: bundle exec rake test
+          

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.1.9
-  - 2.2.2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://api.travis-ci.org/Shopify/omniauth-shopify-oauth2.png?branch=master)](http://travis-ci.org/Shopify/omniauth-shopify-oauth2)
+[![Build Status](https://github.com/Shopify/omniauth-shopify-oauth2/workflows/CI/badge.svg?branch=master)](https://github.com/Shopify/omniauth-shopify-oauth2/actions)
 
 # OmniAuth Shopify
 


### PR DESCRIPTION
We want to move away from running the CI on travis.org due the platform going into [read-only mode at the end of the year](https://docs.travis-ci.com/user/migrate/open-source-repository-migration/#frequently-asked-questions).