### PR TITLE
Limit omniauth-oauth2 dep to last working version

### DIFF
--- a/omniauth-shopify-oauth2.gemspec
+++ b/omniauth-shopify-oauth2.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.1.9'
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.5'
+  s.add_runtime_dependency 'omniauth-oauth2', ['~> 1.5', '< 1.7.1']
   s.add_runtime_dependency 'activesupport'
 
   s.add_development_dependency 'minitest', '~> 5.6'


### PR DESCRIPTION
When `omniauth-oauth2` was updated from version `1.7.0` to `1.7.1`, it bumped its internal dependency to omniauth v>=2, which strangely enough was not considered a breaking change.

Omniauth v2 stops supporting `GET` requests to initiate OAuth, which breaks existing apps using `shopify_app`. Once we figure out a solution for this, we can release a new major version for this gem to avoid breaking existing apps.