### PR TITLE
Update omniauth-oauth2 dependency to include 1.7.1+

### DIFF
--- a/omniauth-shopify-oauth2.gemspec
+++ b/omniauth-shopify-oauth2.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.1.9'
 
-  s.add_runtime_dependency 'omniauth-oauth2', ['~> 1.5', '< 1.7.1']
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.5'
   s.add_runtime_dependency 'activesupport'
 
   s.add_development_dependency 'minitest', '~> 5.6'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,4 +8,6 @@ require 'json'
 require 'active_support/core_ext/hash'
 
 OmniAuth.config.logger = Logger.new(nil)
+OmniAuth.config.allowed_request_methods = [:post, :get]
+
 FakeWeb.allow_net_connect = false


### PR DESCRIPTION
`1.7.1` of `omniauth-oauth2` included a runtime dependency of version 2 of `omniauth` which disabled use of `GET` for OAuth flows ([Resolving CVE 2015-9284](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284)).  `shopify_app` relies on `GET` for OAuth flows.

Initializer configurations of `omniauth` in `shopify_app` now enable `GET` ([Shopify/shopify_app#1175](https://github.com/Shopify/shopify_app/pull/1175)), so the limitation of `< 1.7.1` can now be removed.