### PR TITLE
Update example for Omniauth 2.x

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -3,4 +3,5 @@ source 'https://rubygems.org/'
 gem 'rack', '~> 1.6'
 
 gem 'sinatra', '~> 1.4'
+gem 'omniauth', '~> 2.0.4'
 gem 'omniauth-shopify-oauth2', :path => '../'

--- a/example/config.ru
+++ b/example/config.ru
@@ -19,7 +19,8 @@ class App < Sinatra::Base
       <title>Shopify Oauth2</title>
     </head>
     <body>
-      <form action="/auth/shopify" method="get">
+      <form action="/auth/shopify" method="post">
+      <input type="hidden" name="authenticity_token" value="#{env['rack.session'][:csrf]}" />
       <label for="shop">Enter your store's URL:</label>
       <input type="text" name="shop" placeholder="your-shop-url.myshopify.com">
       <button type="submit">Log In</button>
@@ -60,9 +61,25 @@ class App < Sinatra::Base
 end
 
 use Rack::Session::Cookie, secret: SecureRandom.hex(64)
+use Rack::Protection::AuthenticityToken
+
+OmniAuth.config.allowed_request_methods = [:post]
 
 use OmniAuth::Builder do
-  provider :shopify, SHOPIFY_API_KEY, SHOPIFY_SHARED_SECRET, :scope => SCOPE
+  provider :shopify,
+    SHOPIFY_API_KEY,
+    SHOPIFY_SHARED_SECRET,
+    scope: SCOPE,
+    setup: lambda { |env|
+      shop = if env['REQUEST_METHOD'] == 'POST'
+        env['rack.request.form_hash']['shop']
+      else
+        Rack::Utils.parse_query(env['QUERY_STRING'])['shop']
+      end
+
+      site_url = "https://#{shop}"
+      env['omniauth.strategy'].options[:client_options][:site] = site_url
+    }
 end
 
 run App.new


### PR DESCRIPTION
Update the example application to show how to use it with omniauth 2.x which forces `post` for login. 
Related to https://github.com/Shopify/omniauth-shopify-oauth2/issues/97 and https://github.com/Shopify/omniauth-shopify-oauth2/issues/72