### PR TITLE
Expand the set of minor Ruby versions tested by CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     name: Ruby ${{ matrix.version }}
     strategy:
       matrix:
-        version: [2.5.0, 2.7.1]
+        version: [2.5, 2.6, 2.7, '3.0', 3.1]
 
     steps:
       - uses: actions/checkout@v2

--- a/example/config.ru
+++ b/example/config.ru
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'sinatra/base'
+require 'active_support'
 require 'active_support/core_ext/hash'
 require 'omniauth-shopify-oauth2'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'omniauth-shopify-oauth2'
 require 'minitest/autorun'
 require 'fakeweb'
 require 'json'
+require 'active_support'
 require 'active_support/core_ext/hash'
 
 OmniAuth.config.logger = Logger.new(nil)


### PR DESCRIPTION
Include Ruby 3.0, 3.1, as well as 2.6.

To address changes in class loading in Active Support 7.0 a minor change was required in the `test/test_helper.rb` file to get everything running green.