### PR TITLE
Stop validating that returned scope matches requested scope

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -73,13 +73,6 @@ module OmniAuth
         validate_signature(new_secret) || (old_secret && validate_signature(old_secret))
       end
 
-      def valid_scope?(token)
-        params = options.authorize_params.merge(options_for("authorize"))
-        return false unless token && params[:scope] && token['scope']
-        expected_scope = normalized_scopes(params[:scope]).sort
-        (expected_scope == token['scope'].split(SCOPE_DELIMITER).sort)
-      end
-
       def normalized_scopes(scopes)
         scope_list = scopes.to_s.split(SCOPE_DELIMITER).map(&:strip).reject(&:empty?).uniq
         ignore_scopes = scope_list.map { |scope| scope =~ /\A(unauthenticated_)?write_(.*)\z/ && "#{$1}read_#{$2}" }.compact
@@ -128,9 +121,6 @@ module OmniAuth
         return fail!(:invalid_signature, CallbackError.new(:invalid_signature, "Signature does not match, it may have been tampered with.")) unless valid_signature?
 
         token = build_access_token
-        unless valid_scope?(token)
-          return fail!(:invalid_scope, CallbackError.new(:invalid_scope, "Scope does not match, it may have been tampered with."))
-        end
         unless valid_permissions?(token)
           return fail!(:invalid_permissions, CallbackError.new(:invalid_permissions, "Requested API access mode does not match."))
         end

--- a/omniauth-shopify-oauth2.gemspec
+++ b/omniauth-shopify-oauth2.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5.6'
   s.add_development_dependency 'rspec', '~> 3.9.0'
   s.add_development_dependency 'fakeweb', '~> 1.3'
+  s.add_development_dependency 'rack-session', '~> 2.0'
   s.add_development_dependency 'rake'
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -206,29 +206,27 @@ class IntegrationTest < Minitest::Test
     assert_equal '/auth/failure?message=csrf_detected&strategy=shopify', response.location
   end
 
-  def test_callback_with_mismatching_scope_fails
+  def test_callback_with_mismatching_scope_succeeds
     access_token = SecureRandom.hex(16)
     code = SecureRandom.hex(16)
     expect_access_token_request(access_token, 'some_invalid_scope', nil)
 
     response = callback(sign_with_new_secret(shop: 'snowdevil.myshopify.com', code: code, state: opts["rack.session"]["omniauth.state"]))
 
-    assert_equal 302, response.status
-    assert_equal '/auth/failure?message=invalid_scope&strategy=shopify', response.location
+    assert_callback_success(response, access_token, code)
   end
 
-  def test_callback_with_no_scope_fails
+  def test_callback_with_no_scope_succeeds
     access_token = SecureRandom.hex(16)
     code = SecureRandom.hex(16)
     expect_access_token_request(access_token, nil)
 
     response = callback(sign_with_new_secret(shop: 'snowdevil.myshopify.com', code: code, state: opts["rack.session"]["omniauth.state"]))
 
-    assert_equal 302, response.status
-    assert_equal '/auth/failure?message=invalid_scope&strategy=shopify', response.location
+    assert_callback_success(response, access_token, code)
   end
 
-  def test_callback_with_missing_access_scope_fails
+  def test_callback_with_missing_access_scope_succeeds
     build_app scope: 'first_scope,second_scope'
 
     access_token = SecureRandom.hex(16)
@@ -237,11 +235,10 @@ class IntegrationTest < Minitest::Test
 
     response = callback(sign_with_new_secret(shop: 'snowdevil.myshopify.com', code: code, state: opts["rack.session"]["omniauth.state"]))
 
-    assert_equal 302, response.status
-    assert_equal '/auth/failure?message=invalid_scope&strategy=shopify', response.location
+    assert_callback_success(response, access_token, code)
   end
 
-  def test_callback_with_extra_access_scope_fails
+  def test_callback_with_extra_access_scope_succeeds
     build_app scope: 'first_scope,second_scope'
 
     access_token = SecureRandom.hex(16)
@@ -250,8 +247,7 @@ class IntegrationTest < Minitest::Test
 
     response = callback(sign_with_new_secret(shop: 'snowdevil.myshopify.com', code: code, state: opts["rack.session"]["omniauth.state"]))
 
-    assert_equal 302, response.status
-    assert_equal '/auth/failure?message=invalid_scope&strategy=shopify', response.location
+    assert_callback_success(response, access_token, code)
   end
 
   def test_callback_with_scopes_out_of_order_works

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'bundler/setup'
 require 'omniauth-shopify-oauth2'
 
 require 'minitest/autorun'
+require 'rack/session'
 require 'fakeweb'
 require 'json'
 require 'active_support/core_ext/hash'


### PR DESCRIPTION
We've determined that this does not constitute a security issue in Shopify's context and we'd like the flexibility to return a different set of scopes in the future.