### PR TITLE
Bump version to 2.4.0

### DIFF
--- a/lib/omniauth/shopify/version.rb
+++ b/lib/omniauth/shopify/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Shopify
-    VERSION = "2.3.2"
+    VERSION = "2.4.0"
   end
 end


### PR DESCRIPTION
Following the pattern from the last bump: https://github.com/Shopify/omniauth-shopify-oauth2/pull/107

I think a minor version bump is most appropriate in this case.

The relevant PR is this one: https://github.com/Shopify/omniauth-shopify-oauth2/pull/116

I contextualize the change as a new, backwards-compatible feature that allows the scopes returned with the token to be different than those requested. Since this relaxes a restriction, it will not break OAuth flows that are currently succeeding (and will only allow additional configurations to succeed).

There are cases where a behavioural change such as this could be construed as a breaking change, i.e. if users were relying on a validation to enforce an important security requirement.

In this case, we've determined that there's no legitimate business or security reason for Shopify apps to enforce this check. Thus, we do not need to concern ourselves with the behavioural change when considering semver.