### PR TITLE
Calculate refresh_token_expires_at

### DIFF
--- a/lib/omniauth/strategies/shopify.rb
+++ b/lib/omniauth/strategies/shopify.rb
@@ -155,6 +155,14 @@ module OmniAuth
         options[:callback_url] || full_host + script_name + callback_path
       end
 
+      def credentials
+        hash = super
+        if (expires_in = access_token['refresh_token_expires_in'])
+          hash['refresh_token_expires_at'] = Time.now.to_i + expires_in.to_i
+        end
+        hash
+      end
+
       private
 
       def validate_signature(secret)

--- a/spec/omniauth/strategies/shopify_spec.rb
+++ b/spec/omniauth/strategies/shopify_spec.rb
@@ -97,6 +97,7 @@ describe OmniAuth::Strategies::Shopify do
       @access_token.stub(:expires?)
       @access_token.stub(:expires_at)
       @access_token.stub(:refresh_token)
+      @access_token.stub(:[]) { nil }
       subject.stub(:access_token) { @access_token }
     end
 
@@ -115,6 +116,18 @@ describe OmniAuth::Strategies::Shopify do
 
       @access_token.stub(:expires?) { false }
       subject.credentials['expires'].should eq(false)
+    end
+
+    it 'sets refresh_token_expires_at when refresh_token_expires_in is present' do
+      now = Time.now.to_i
+      @access_token.stub(:[]).with('refresh_token_expires_in') { 86400 }
+      result = subject.credentials
+      result['refresh_token_expires_at'].should be_within(2).of(now + 86400)
+    end
+
+    it 'does not set refresh_token_expires_at when refresh_token_expires_in is absent' do
+      @access_token.stub(:[]).with('refresh_token_expires_in') { nil }
+      subject.credentials.should_not have_key('refresh_token_expires_at')
     end
 
   end


### PR DESCRIPTION
For expiring offline access tokens, Shopify provides access token expiration (expires_in) and refresh token expiration (refresh_token_expires_in). This PR makes refresh token available to the application.

https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens